### PR TITLE
Ellipse

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.7-beta2
 StaticArrays 0.8.2
 Requires 0.5.2
 MuladdMacro 0.2.0
+Elliptic 0.5.0

--- a/docs/src/basic/phasespaces.md
+++ b/docs/src/basic/phasespaces.md
@@ -11,6 +11,7 @@ systems, using:
 to_bcoords
 from_bcoords
 arcintervals
+totallength
 ```
 
 ## Boundary Maps

--- a/docs/src/tutorials/own_obstacle.md
+++ b/docs/src/tutorials/own_obstacle.md
@@ -5,7 +5,7 @@ In this tutorial we will go through the processes of creating a new obstacle typ
 [`billiard_mushroom`](@ref) functions.
 
 !!! info "Everything uses `SVector{2}`"
-    Fields of `Particle`s and `Obstacle`s contain all their information in 2-dimensional static vectors from module `StaticArrays`. This is important to keep in mind when extending new methods.
+    Fields of `Particle`s and `Obstacle`s contain all their vector-related information in 2-dimensional static vectors from module `StaticArrays`. This is important to keep in mind when extending new methods.
 
 ## Type Definition
 The first thing you have to do is make your new type a sub-type of `Obstacle{T}`
@@ -125,16 +125,16 @@ function collisiontime(p::Particle{T}, d::Semicircle{T})::T where {T}
 end
 ```
 
-And that is all. The obstacle now works perfectly fine for straight propagation.
+And that is all. The obstacle now works perfectly fine for straight propagation of any kind! This includes periodic billiards (both rectangular and hexagonal).
 
 
 
 ## Optional Methods
 
-1. [`cellsize`](@ref) : Enables [`randominside`](@ref) with this obstacle.
+1. [`cellsize`](@ref) : Enables [`randominside`](@ref) with this obstacle
 1. [`collisiontime`](@ref) with [`MagneticParticle`](/basic/high_level/#particles) : enables magnetic propagation
-2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot_billiard`](@ref)) (but requires [`cellsize`](@ref) to be already implemented, because [`plot_billiard`](@ref) also does automatic axis limits configuration)
-1. [`translate`](@ref) : Enables plotting the obstacle with periodic billiards
+2. [`plot_obstacle`](@ref) : enables plotting (requires [`cellsize`](@ref) to be already implemented, because [`plot_billiard`](@ref) also does automatic axis limits configuration)
+1. [`translate`](@ref) : Enables plotting the obstacle with periodic billiards (you can still use the obstacle with periodic billiards even without `translate`)
 3. [`to_bcoords`](@ref) & [`totallength`](@ref) : Allows the [`boundarymap`](@ref) and [`boundarymap_portion`](@ref) to be computed.
 4. [`from_bcoords`](@ref) : Allows [`phasespace_portion`](@ref) to be computed.
 

--- a/docs/src/tutorials/own_obstacle.md
+++ b/docs/src/tutorials/own_obstacle.md
@@ -135,7 +135,7 @@ And that is all. The obstacle now works perfectly fine for straight propagation.
 1. [`collisiontime`](@ref) with [`MagneticParticle`](/basic/high_level/#particles) : enables magnetic propagation
 2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot_billiard`](@ref)) (but requires [`cellsize`](@ref) to be already implemented, because [`plot_billiard`](@ref) also does automatic axis limits configuration)
 1. [`translate`](@ref) : Enables plotting the obstacle with periodic billiards
-3. [`to_bcoords`](@ref) : Allows the [`boundarymap`](@ref) and [`boundarymap_portion`](@ref) to be computed.
+3. [`to_bcoords`](@ref) & [`totallength`](@ref) : Allows the [`boundarymap`](@ref) and [`boundarymap_portion`](@ref) to be computed.
 4. [`from_bcoords`](@ref) : Allows [`phasespace_portion`](@ref) to be computed.
 
 The [`cellsize`](@ref) method is kinda trivial:

--- a/docs/src/tutorials/own_obstacle.md
+++ b/docs/src/tutorials/own_obstacle.md
@@ -134,6 +134,7 @@ And that is all. The obstacle now works perfectly fine for straight propagation.
 1. [`cellsize`](@ref) : Enables [`randominside`](@ref) with this obstacle.
 1. [`collisiontime`](@ref) with [`MagneticParticle`](/basic/high_level/#particles) : enables magnetic propagation
 2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot_billiard`](@ref))
+1. [`translate`](@ref) : Enables plotting the obstacle with periodic billiards
 3. [`to_bcoords`](@ref) : Allows the [`boundarymap`](@ref) and [`boundarymap_portion`](@ref) to be computed.
 4. [`from_bcoords`](@ref) : Allows [`phasespace_portion`](@ref) to be computed.
 

--- a/docs/src/tutorials/own_obstacle.md
+++ b/docs/src/tutorials/own_obstacle.md
@@ -39,8 +39,8 @@ end
 so that constructing a `Semicircle` is possible from arbitrary vectors.
 
 ## Necessary Methods
-The following functions must obtain methods for `Semicircle` (or any other custom
-`Obstacle`) in order for it to work with `DynamicalBilliards`:
+The following functions must obtain methods for your custom
+`Obstacle` in order for it to work with `DynamicalBilliards`:
 
 1. [`normalvec`](@ref)
 2. [`distance`](@ref) (with arguments `(position, obstacle)`)
@@ -133,7 +133,7 @@ And that is all. The obstacle now works perfectly fine for straight propagation.
 
 1. [`cellsize`](@ref) : Enables [`randominside`](@ref) with this obstacle.
 1. [`collisiontime`](@ref) with [`MagneticParticle`](/basic/high_level/#particles) : enables magnetic propagation
-2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot_billiard`](@ref))
+2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot_billiard`](@ref)) (but requires [`cellsize`](@ref) to be already implemented, because [`plot_billiard`](@ref) also does automatic axis limits configuration)
 1. [`translate`](@ref) : Enables plotting the obstacle with periodic billiards
 3. [`to_bcoords`](@ref) : Allows the [`boundarymap`](@ref) and [`boundarymap_portion`](@ref) to be computed.
 4. [`from_bcoords`](@ref) : Allows [`phasespace_portion`](@ref) to be computed.

--- a/src/DynamicalBilliards.jl
+++ b/src/DynamicalBilliards.jl
@@ -19,6 +19,9 @@ using MuladdMacro
 # to a call to `muladd`
 # This can increase performance in some cases.
 
+import Elliptic
+# Elliptic module allows computing elliptic integrals
+
 const SV = SVector{2}
 export SVector
 

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -502,6 +502,16 @@ function cellsize(a::Semicircle{T}) where {T}
     return xmin, ymin, xmax, ymax
 end
 
+function cellsize(e::Ellipse{T}) where {T}
+    if e.pflag
+        xmin = ymin = T(Inf)
+        xmax = ymax = T(-Inf)
+    else
+        xmin = e.c - e.a; ymin = e.c - e.b
+        xmax = e.c + e.a; ymax = e.c + e.b
+    end
+    return xmin, ymin, xmax, ymax
+end
 
 ####################################################
 ## Translations

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -452,6 +452,10 @@ function distance_init(pos::SVector{2,T}, w::FiniteWall{T})::T where {T}
     dot(v1, n)
 end
 
+function distance(pos::SV, e::Ellipse)
+    # see https://wet-robots.ghost.io/simple-method-for-distance-to-ellipse/
+end
+
 ####################################################
 ## Initial Conditions
 ####################################################

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -324,7 +324,12 @@ on the x and y axis (although you can make whichever you want the major one).
 * `b::T` : y semi-axis.
 * `pflag::Bool` : Flag that keeps track of where the particle is currently
   propagating. `true` (default) is associated with being outside the ellipse.
-* `name::String` : Some name given for user convenience. Defaults to "Ellipse".
+* `name::String` : Some name given for user convenience. Defaults to `"Ellipse"`.
+
+The ellipse equation is given by
+```math
+\\frac{x - c[1]}{a} + \\frac{y - c[2]}{b} = 1
+```
 """
 struct Ellipse{T<:AbstractFloat} <: Obstacle{T}
     c::SVector{2,T}

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -331,13 +331,12 @@ The ellipse equation is given by
 \\left(\\frac{x - c[1]}{a} \\right)^2+ \\left(\\frac{y - c[2]}{b}\\right)^2 = 1
 ```
 """
-struct Ellipse{T<:AbstractFloat} <: Obstacle{T}
+mutable struct Ellipse{T<:AbstractFloat} <: Obstacle{T}
     c::SVector{2,T}
     a::T
     b::T
     pflag::Bool
     name::String
-    # major::Int
 end
 
 function Ellipse(c::AbstractVector{T}, a, b, pflag = true,
@@ -457,7 +456,7 @@ function distance_init(pos::SVector{2,T}, w::FiniteWall{T})::T where {T}
     dot(v1, n)
 end
 
-function distance(pos::SV, e::Ellipse)
+function distance(pos::SV, e::Ellipse{T})::T where {T}
     d = ((pos[1] - e.c[1])/e.a)^2 + ((pos[2]-e.c[2])/e.b)^2 - 1.0
     e.pflag ? d : -d
 end
@@ -507,8 +506,8 @@ function cellsize(e::Ellipse{T}) where {T}
         xmin = ymin = T(Inf)
         xmax = ymax = T(-Inf)
     else
-        xmin = e.c - e.a; ymin = e.c - e.b
-        xmax = e.c + e.a; ymax = e.c + e.b
+        xmin = e.c[1] - e.a; ymin = e.c[2] - e.b
+        xmax = e.c[1] + e.a; ymax = e.c[2] + e.b
     end
     return xmin, ymin, xmax, ymax
 end

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -346,7 +346,7 @@ function Ellipse(c::AbstractVector{T}, a, b, pflag = true,
     return Ellipse{S}(SVector{2,S}(c),
     convert(S, abs(a)), convert(S, abs(b)), pflag, name)
 end
-# Disk{T}(args...) where {T} = Disk(args...)
+Ellipse{T}(args...) where {T} = Ellipse(args...)
 
 #######################################################################################
 ## Normal vectors
@@ -523,10 +523,9 @@ translated by `vector`.
 """
 function translate end
 
-for T in subtypes(Circular)
-  @eval translate(d::$T, vec) = ($T)(d.c .+ vec, d.r)
-end
+translate(d::Circular, vec) = typeof(d)(d.c .+ vec, d.r)
+translate(d::Antidot, vec) = Antidot(d.c .+ vec, d.r, d.pflag)
 
-for T in subtypes(Wall)
-  @eval translate(w::$T, vec) = ($T)(w.sp + vec, w.ep + vec, w.normal)
-end
+translate(w::Wall, vec) = typeof(w)(w.sp + vec, w.ep +vec, w.normal)
+translate(w::SplitterWall, vec) =
+    SplitterWall(w.sp + vec, w.ep +vec, w.normal, w.pflag)

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -529,3 +529,5 @@ translate(d::Antidot, vec) = Antidot(d.c .+ vec, d.r, d.pflag)
 translate(w::Wall, vec) = typeof(w)(w.sp + vec, w.ep +vec, w.normal)
 translate(w::SplitterWall, vec) =
     SplitterWall(w.sp + vec, w.ep +vec, w.normal, w.pflag)
+
+translate(e::Ellipse, vec) = Ellipse(e.c + vec, e.a, e.b, e.pflag)

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -328,7 +328,7 @@ on the x and y axis (although you can make whichever you want the major one).
 
 The ellipse equation is given by
 ```math
-\\frac{x - c[1]}{a} + \\frac{y - c[2]}{b} = 1
+\\left(\\frac{x - c[1]}{a} \\right)^2+ \\left(\\frac{y - c[2]}{b}\\right)^2 = 1
 ```
 """
 struct Ellipse{T<:AbstractFloat} <: Obstacle{T}

--- a/src/billiards/obstacles.jl
+++ b/src/billiards/obstacles.jl
@@ -458,7 +458,8 @@ function distance_init(pos::SVector{2,T}, w::FiniteWall{T})::T where {T}
 end
 
 function distance(pos::SV, e::Ellipse)
-    # see https://wet-robots.ghost.io/simple-method-for-distance-to-ellipse/
+    d = ((pos[1] - e.c[1])/e.a)^2 + ((pos[2]-e.c[2])/e.b)^2 - 1.0
+    e.pflag ? d : -d
 end
 
 ####################################################

--- a/src/billiards/standard_billiards.jl
+++ b/src/billiards/standard_billiards.jl
@@ -9,7 +9,7 @@ billiard_stadium, billiard_mushroom, billiard_logo
 ####################################################
 """
     billiard_rectangle(x=1.0, y=1.0; setting = "standard")
-Return a vector of obstacles that defines a rectangle billiard of size (`x`, `y`).
+Return a rectangle billiard of size (`x`, `y`).
 
 ### Settings
 * "standard" : Specular reflection occurs during collision.
@@ -68,7 +68,7 @@ end
 
 """
     billiard_sinai(r=0.25, x=1.0, y=1.0; setting = "standard")
-Return a vector of obstacles that defines a Sinai billiard of size (`x`, `y`) with
+Return a Sinai billiard of size (`x`, `y`) with
 a disk in its center, of radius `r`.
 
 In the periodic case, the system is also known as "Lorentz Gas".
@@ -111,7 +111,7 @@ billiard_lorentz(r=0.25, x=1.0, y=1.0) = billiard_sinai(r,x,y; setting = "period
 
 """
     billiard_polygon(n::Int, R, center = [0,0]; setting = "standard")
-Return a vector of obstacles that defines a regular-polygonal billiard
+Return a regular-polygonal billiard
 with `n` sides, radius `r` and given `center`.
 
 Note: `R` denotes the so-called outer radius, not the inner one.
@@ -336,4 +336,19 @@ function billiard_logo(;h=1.0, α=0.8, r=0.18, off=0.25)
     newoantidot = ((x, bool) -> bool ? -2.0x : -0.5x)
     raya = RaySplitter([2], transmission_p(0.8), refraction, newoantidot)
     return bd, raya
+end
+
+export billiard_iris
+
+"""
+    billiard_iris(a=0.2, b=0.4, w=1.0; setting = "standard")
+Return a billiard that is a square of side `w` enclosing at its center an ellipse
+with semi axes `a`, `b`.
+"""
+function billiard_iris(a′ = 0.2, b′ = 0.4, w′ = 1.0;
+    setting = "standard", a = a′, b = b′, w = w′)
+
+    rec = billiard_rectangle(w, w; setting = setting)
+    e = Ellipse([w/2, w/2], a, b, true, "Iris")
+    return Billiard(rec.obstacles..., e)
 end

--- a/src/boundary/boundarymap.jl
+++ b/src/boundary/boundarymap.jl
@@ -1,5 +1,5 @@
 export to_bcoords, from_bcoords, arcintervals
-export boundarymap
+export boundarymap, totallength
 #######################################################################################
 ## Arclengths
 #######################################################################################

--- a/src/plotting/obstacles.jl
+++ b/src/plotting/obstacles.jl
@@ -2,12 +2,12 @@ export plot_obstacle
 
 obcolor(::Obstacle) = (0,0.6,0)
 obcolor(::Union{RandomWall, RandomDisk}) = (149/255, 88/255, 178/255)
-obcolor(::Union{SplitterWall, Antidot}) = (0.8,0.0,0)
+obcolor(::Union{SplitterWall, Antidot, Ellipse}) = (0.8,0.0,0)
 obcolor(::PeriodicWall) = (0.8,0.8,0)
 obalpha(::Obstacle) = 0.5
-obalpha(::Antidot) = 0.1
+obalpha(::Union{Antidot, Ellipse}) = 0.1
 obls(::Obstacle) = "solid"
-obls(::Union{SplitterWall, Antidot}) = "dashed"
+obls(::Union{SplitterWall, Antidot, Ellipse}) = "dashed"
 obls(::PeriodicWall) = "dotted"
 
 """
@@ -50,4 +50,13 @@ function plot_obstacle(w::Wall; kwargs...)
         color=obcolor(w),
         linestyle = obls(w), lw = 2.0, kwargs...)
     end
+end
+
+function plot_obstacle(e::Ellipse; kwargs...)
+    edgecolor = obcolor(e)
+    facecolor = (edgecolor..., obalpha(e))
+    ellipse = PyPlot.matplotlib[:patches][:Ellipse](e.c, 2e.a, 2e.b;
+        edgecolor = edgecolor, facecolor = facecolor,
+        linestyle = obls(e), lw = 2.0, kwargs...)
+    PyPlot.gca()[:add_artist](ellipse)
 end

--- a/src/timeevolution/collisiontimes.jl
+++ b/src/timeevolution/collisiontimes.jl
@@ -110,7 +110,11 @@ end
     t ≤ 0.0 ? Inf : t
 end
 
-
+@muladd function collisiontime(p::Particle{T}, e::Ellipse{T}) where {T}
+    # translate particle pos by ellipse center to assume ellipse center at 0
+    # then get the m and c of the line defined by the particle
+    # http://www.ambrsoft.com/TrigoCalc/Circles2/Ellipse/EllipseLine.htm
+end
 
 #######################################################################################
 ## Magnetic particle

--- a/src/timeevolution/collisiontimes.jl
+++ b/src/timeevolution/collisiontimes.jl
@@ -114,6 +114,7 @@ end
 @muladd function collisiontime(p::Particle{T}, e::Ellipse{T}) where {T}
     # First check if particle is "looking at" eclipse if it is outside
     if e.pflag
+        # These lines may be wrong
         dotp = dot(p.vel, normalvec(e, p.pos))
         dotp >= 0.0 && return T(Inf)
     end
@@ -183,7 +184,7 @@ end
     p1 = o.c
     r1 = o.r
     d = norm(p1-pc)
-    if (d >= rc + r1) || (d <= abs(rc-r1))
+    if (d ≥ rc + r1) || (d ≤ abs(rc-r1))
         return Inf
     end
     # Solve quadratic:

--- a/src/timeevolution/collisiontimes.jl
+++ b/src/timeevolution/collisiontimes.jl
@@ -114,7 +114,7 @@ end
 @muladd function collisiontime(p::Particle{T}, e::Ellipse{T}) where {T}
     # First check if particle is "looking at" eclipse if it is outside
     if e.pflag
-        # These lines may be wrong
+        # These lines may be "not accurate enough" but so far all is good
         dotp = dot(p.vel, normalvec(e, p.pos))
         dotp >= 0.0 && return T(Inf)
     end
@@ -140,8 +140,9 @@ end
         # one. Analytically I mean. But I haven't found yet.
         d1 = norm(pc - I1); d2 = norm(pc - I2)
         return min(d1, d2)
-    else
-        error("not implemented yet")
+    else # If inside the ellipse, only one collision valid
+        dotp = dot(p.vel, (I1 - pc))
+        return dotp ≥ 0.0 ? norm(pc - I1) : norm(pc - I2)
     end
 end
 

--- a/src/timeevolution/propagation.jl
+++ b/src/timeevolution/propagation.jl
@@ -93,10 +93,8 @@ the ray-splitting dictionary that is passed directly to `evolve!()`. For a calcu
 incidence angle φ, if T(φ) > rand(), ray-splitting occurs.
 """
 @inline resolvecollision!(p::Particle, o::Obstacle) = specular!(p, o)
-@inline resolvecollision!(p::Particle, o::PeriodicWall) = periodicity!(p, o)
+@inline resolvecollision!(p::AbstractParticle, o::PeriodicWall) = periodicity!(p, o)
 @inline resolvecollision!(p::MagneticParticle, o::Obstacle) = specular!(p, o)
-
-resolvecollision!(p::MagneticParticle, o::PeriodicWall) = periodicity!(p, o)
 
 
 """

--- a/src/timeevolution/propagation.jl
+++ b/src/timeevolution/propagation.jl
@@ -92,9 +92,9 @@ This is the ray-splitting implementation. The three functions given are drawn fr
 the ray-splitting dictionary that is passed directly to `evolve!()`. For a calculated
 incidence angle φ, if T(φ) > rand(), ray-splitting occurs.
 """
-@inline resolvecollision!(p::Particle, o::Obstacle) = specular!(p, o)
-@inline resolvecollision!(p::AbstractParticle, o::PeriodicWall) = periodicity!(p, o)
-@inline resolvecollision!(p::MagneticParticle, o::Obstacle) = specular!(p, o)
+@inline resolvecollision!(p::AbstractParticle, o::Obstacle) = specular!(p, o)
+@inline resolvecollision!(p::Particle, o::PeriodicWall) = periodicity!(p, o)
+@inline resolvecollision!(p::MagneticParticle, o::PeriodicWall) = periodicity!(p, o)
 
 
 """

--- a/test/ellipse_tests.jl
+++ b/test/ellipse_tests.jl
@@ -1,0 +1,39 @@
+using Test
+using DynamicalBilliards
+
+function ellipse_tests(partnum=500; printinfo = true)
+tim = time()
+@testset "Ellipse Arclength" begin
+    o1 = Ellipse([0,0], 1.0, 0.5)
+    o2 = Ellipse([0,0], 0.5, 1.0)
+
+    for x in [o1, o2]
+        for y in [o1, o2]
+            @test ellipse_arclength(π/2, x) == y.arc
+        end
+        @test ellipse_arclength(π, x) == 2x.arc
+        @test ellipse_arclength(2π, x) == 4x.arc
+        @test ellipse_arclength(π/2, x) + 2x.arc == ellipse_arclength(3π/2, x)
+    end
+
+    phis = 0.0:0.01:2π
+
+    for i in 2:length(phis)
+        @test ellipse_arclength(phis[i], o1) > ellipse_arclength(phis[i-1], o1)
+    end
+
+
+
+
+end#testset
+if printinfo
+    println("Results:")
+    println("+ Ellipse obstacle has proper arclengths.")
+    # println("+ randominside() works with Ellipse.")
+    # println("+ relocate(), collisiontime(), resolvecollision() work for")
+    # println("  standard particle and Ellipse.")
+    # println("+ Ray-splitting works with Ellipse.")
+    println("+ Required time: $(round(time()-tim, digits=3)) sec.")
+end
+return
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ include("raysplit.jl")
 include("various.jl")
 include("lyapunov.jl")
 include("psos.jl")
+include("ellipse_tests.jl")
 
 print("DynamicalBilliards tests started at: ")
 print(Dates.format(now(), "HH:MM:s"), "\n")
@@ -42,7 +43,8 @@ fnames = (
     type_stability, lyapunov_spectrum,
     lyapunov_magnetic, escape_times, stadium_bm, cut_psos, coordinates_test,
     boundarymap_portion_test, phasespace_portion_test, meancoltimes,
-    raysplit_straight, raysplit_magnetic, noparticle_interafaces, ispinned_tests)
+    raysplit_straight, raysplit_magnetic, noparticle_interafaces, ispinned_tests,
+    ellipse_tests)
 
 for f in fnames
     println()


### PR DESCRIPTION
This PR does a huge amount of stuff:

- [x] Adds new obstacle, `Ellipse`, that represents a triangle. JUST KIDDING IT REPRESENTS AN ELLIPSE< WHO WOULD HAVE THOUGHT
- [x] Implements methods for straight propagation with ellipse (`distance, normalvec, collisiontime`).
- [x] Closes #143 
- [x] Allows plotting and plotting with periodic billiards
- [x] allows `randominside` with `Ellipse`.
- [x] adds a new billiard: `billiard_iris`, that is Sinai with Ellipse.
- [x] adds full support for ray-splitting with Ellipse

**This PR also introduces a dependency on the module `Elliptic`, that computes elliptic integrals. It is pure Julia so it is fine**

Still left to do:

- [ ] Add tests for evolution with Ellipse
- [ ] Fix/implement `to_bcoords/from_`.
- [ ] Rework/improve documentation of `distance`, since this is not the exact distance but doesn't matter.
- [ ] Link this PR to the "Create Obstacle" documentation page. 

--- 

This was a good programming exercise I have to admit!