### PR TITLE
Use multiple dispatch for `plot` functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
     on_failure: always
 
 after_success:
-  - test $TRAVIS_OS_NAME = "linux" && julia -e 'using Pkg; ENV["PYTHON"]=""; py="PyCall"; Pkg.add(py); Pkg.build(); Pkg.add("PyPlot")'
+  - test $TRAVIS_OS_NAME = "linux" && julia -e 'using Pkg; ENV["PYTHON"]=""; py="PyCall"; Pkg.add(py); Pkg.build(); Pkg.add("PyPlot"); Pkg.add("StaticArrays")'
   - test $TRAVIS_OS_NAME = "linux" && julia -e 'using Pkg; Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))'
 #  - julia -e 'cd(Pkg.dir("DynamicalBilliards")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 #  - julia -e 'cd(Pkg.dir("DynamicalBilliards")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,22 @@
 # 3.0-dev
 
 ## TODO
-* update docs
-* Overload plot
 * update Lyapunov exponents to new interface
-
 
 ## Enhancements / new features
 * Much more robust propagation algorithm that is less prone to errors and "weird behaviors"!
 * Test suite reworked almost from scratch: More tests, more specific tests, more robust tests, easier to debug tests!
 * `totallength` is exported
 
-## Low-Level changes:
+## Breaking changes
+* Plotting functions now overload `plot` instead. There is no more `plot_obstacle`, `plot_billiard` and `plot_particle`. `plot_boundarymap` and `animate_evolution` remain the same though.
+
+## Low-Level changes
 These changes are not actually breaking, unless someone used the low-level interface. The docs also changed and much less than the low level interface is exposed.
 
 * Renamed `collisiontime` to just `collision`, since now it returns both the time and the estimated collision point.
 
-* Many low-level functions are not exported any more, for safety and because it didn't make much sense: `normvalvec, distance, cellsize, ``propagate!`, `relocate!`, `resolvecollision!`, `periodicity!`, `specular!` `realangle`. For the low level interface only `propagate!`, `bounce!`, `collision` and `next_collision` are exposed. Only `bounce!` is exposed as public API. The low level interface is _still_ documented though. 
+* Many low-level functions are not exported any more, for safety and because it didn't make much sense: `normvalvec, distance, cellsize, ``propagate!`, `relocate!`, `resolvecollision!`, `periodicity!`, `specular!` `realangle`. For the low level interface only `propagate!`, `bounce!`, `collision` and `next_collision` are exposed. Only `bounce!` is exposed as public API. The low level interface is _still_ documented though.
 
 * Change of the internal propagation algorithm:
   1. the function `collision` (previously `collisiontime`) returns both the time until collision *as well as* the collision point (most methods computed it already anyways).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,17 +2,16 @@ using DynamicalBilliards
 
 using Documenter, PyPlot
 
-using Pkg
-pkg"add StaticArrays"
-
 ioff()
 makedocs(modules=[DynamicalBilliards], doctest=false, root = @__DIR__)
 close("all")
 
-deploydocs(
-    deps   = Deps.pip("mkdocs==0.17.5", "mkdocs-material==2.9.4",
-    "python-markdown-math", "pygments", "pymdown-extensions"),
-    repo   = "github.com/JuliaDynamics/DynamicalBilliards.jl.git",
-    julia  = "1.0",
-    osname = "linux"
-)
+if !Sys.iswindows()
+    deploydocs(
+        deps   = Deps.pip("mkdocs==0.17.5", "mkdocs-material==2.9.4",
+        "python-markdown-math", "pygments", "pymdown-extensions"),
+        repo   = "github.com/JuliaDynamics/DynamicalBilliards.jl.git",
+        julia  = "1.0",
+        osname = "linux"
+    )
+end

--- a/docs/src/dynamicalbilliards_logo.jl
+++ b/docs/src/dynamicalbilliards_logo.jl
@@ -69,7 +69,7 @@ mkpath("dynamicalbilliards")
 cd("dynamicalbilliards")
 
 figure(figsize = (14,14))
-plot_billiard(bd; ax = gca())
+plot(bd; ax = gca())
 axis("off")
 animate_evolution(p, bd, 500, raya;
 newfig = false, savename="logo", deletefigs = false, col_to_plot = 7);

--- a/docs/src/ray-splitting.md
+++ b/docs/src/ray-splitting.md
@@ -21,7 +21,7 @@ bd = Billiard(a1, a2, sw, bdr...)
 
 ```@example ray
 using PyPlot
-plot_billiard(bd)
+plot(bd)
 savefig("raybil.svg"); nothing # hide
 ```
 ![](raybil.svg)
@@ -88,7 +88,7 @@ For example,
 p = randominside(bd, 1.0)
 raysplitters = (raywall, raya)
 xt, yt, vxt, vyt, tt = construct(evolve(p, bd, 100, raysplitters)...)
-plot_billiard(bd)
+plot(bd)
 plot(xt, yt)
 scatter(xt[1], yt[1], color = "black")
 savefig("rayorbit.svg"); nothing # hide
@@ -177,7 +177,7 @@ p = randominside(bd, 0.4);
 
 and we animate its evolution, by first zooming out of the billiard
 ```julia
-plot_billiard(bd)
+plot(bd)
 xlim(-1, 2); ylim(-1, 2);
 animate_evolution(p, bd, 100, (ray,); newfig = false, savename = "inverse")
 ```

--- a/docs/src/ray-splitting.md
+++ b/docs/src/ray-splitting.md
@@ -15,7 +15,7 @@ x, y = 2.0, 1.0
 bdr =  billiard_rectangle(x, y)
 sw = SplitterWall([x/2, 0.0], [x/2,y], [-1,0], true)
 a1 = Antidot([x/4, y/2], 0.25, "Left Antidot")
-a2 = Ellipse([3x/4, y/2], 0.15, 0.25, true, "Ellipse")
+a2 = Antidot([3x/4, y/2], 0.15, "Right Antidot")
 bd = Billiard(a1, a2, sw, bdr...)
 ```
 

--- a/docs/src/tutorials/billiard_table.md
+++ b/docs/src/tutorials/billiard_table.md
@@ -52,10 +52,10 @@ push!(bd, d)
 # Make the structure required:
 billiard = Billiard(bd)
 ```
-To make sure the billiard looks as you would expect, use the function `plot_billiard(bd)`. Create a particle inside that billiard and evolve it:
+To make sure the billiard looks as you would expect, use the function `plot(bd)`. Create a particle inside that billiard and evolve it:
 ```@example tut1
 using PyPlot
-plot_billiard(billiard)
+plot(billiard)
 ω = 0.5
 p = randominside(billiard, ω)
 xt, yt, vxt, vyt, t = construct(evolve!(p, billiard, 100)...)

--- a/docs/src/tutorials/billiard_table.md
+++ b/docs/src/tutorials/billiard_table.md
@@ -60,7 +60,7 @@ plot(billiard)
 p = randominside(billiard, ω)
 xt, yt, vxt, vyt, t = construct(evolve!(p, billiard, 100)...)
 plot(xt, yt)
-plot_particle(p)
+plot(p)
 savefig("tut1.svg"); nothing # hide
 ```
 ![](tut1.svg)

--- a/docs/src/tutorials/examples.md
+++ b/docs/src/tutorials/examples.md
@@ -66,7 +66,7 @@ mkpath("dynamicalbilliards")
 cd("dynamicalbilliards")
 
 figure(figsize = (14,14))
-plot_billiard(bd; ax = gca())
+plot(bd; ax = gca())
 axis("off")
 animate_evolution(p, bd, 500, raya;
 newfig = false, savename="logo", deletefigs = false, col_to_plot = 7);
@@ -119,7 +119,7 @@ p = randominside(bd)
 p.pos = [0.311901, 0.740439]
 p.vel = [0.548772, 0.835972]
 xt, yt, vxt, vyt, t = construct(evolve(p, bd, 25)...)
-plot_billiard(bd, xt, yt)
+plot(bd, xt, yt)
 scatter(xt[1], yt[1])
 scatter(xt[end], yt[end], color = "black")
 ylim(0,y)

--- a/docs/src/tutorials/own_obstacle.md
+++ b/docs/src/tutorials/own_obstacle.md
@@ -138,7 +138,7 @@ And that is all. The obstacle now works perfectly fine for straight propagation.
 
 1. [`DynamicalBilliards.cellsize`](@ref) : Enables [`randominside`](@ref) with this obstacle.
 1. [`collision`](@ref) with [`MagneticParticle`](/basic/high_level/#particles) : enables magnetic propagation
-2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot_billiard`](@ref))
+2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot`](@ref))
 3. [`to_bcoords`](@ref) : Allows the [`boundarymap`](@ref) and [`boundarymap_portion`](@ref) to be computed.
 4. [`from_bcoords`](@ref) : Allows [`phasespace_portion`](@ref) to be computed.
 

--- a/docs/src/tutorials/own_obstacle.md
+++ b/docs/src/tutorials/own_obstacle.md
@@ -138,13 +138,13 @@ And that is all. The obstacle now works perfectly fine for straight propagation.
 
 1. [`DynamicalBilliards.cellsize`](@ref) : Enables [`randominside`](@ref) with this obstacle.
 1. [`collision`](@ref) with [`MagneticParticle`](/basic/high_level/#particles) : enables magnetic propagation
-2. [`plot_obstacle`](@ref) : enables plotting (used in [`plot`](@ref))
+2. [`plot`](@ref) : enables plotting (used in [`plot`](@ref))
 3. [`to_bcoords`](@ref) : Allows the [`boundarymap`](@ref) and [`boundarymap_portion`](@ref) to be computed.
 4. [`from_bcoords`](@ref) : Allows [`phasespace_portion`](@ref) to be computed.
 
 The [`DynamicalBilliards.cellsize`](@ref) method is kinda trivial:
 ```julia
-import DynamicalBilliards: cellsize, plot_obstacle, to_bcoords, from_bcoords
+import DynamicalBilliards: cellsize, plot, to_bcoords, from_bcoords
 
 function cellsize(a::Semicircle{T}) where {T}
     xmin, ymin = a.c - a.r
@@ -193,12 +193,12 @@ end
 
 ```
 
-Then, we add swag by writing a method for [`plot_obstacle`](@ref):
+Then, we add swag by writing a method for [`plot`](@ref):
 
 ```julia
 using PyPlot
 
-function plot_obstacle(d::Semicircle; kwargs...)
+function plot(d::Semicircle; kwargs...)
     theta1 = atan(d.facedir[2], d.facedir[1])*180/π + 90
     theta2 = theta1 + 180
     edgecolor = DynamicalBilliards.obcolor(d)

--- a/docs/src/visualizing.md
+++ b/docs/src/visualizing.md
@@ -2,10 +2,10 @@ All plotting functionality of `DynamicalBilliards` lies within a few well-define
 
 All plotting functions are brought into scope when `using PyPlot`. The functions are:
 ```@docs
+DynamicalBilliards.plot
 plot_obstacle
 plot_particle
 plot_cyclotron
-plot_billiard
 animate_evolution
 ```
 
@@ -34,16 +34,16 @@ a = Antidot([0.0,0.0], 0.5)
 bd = Billiard(b.obstacles..., a)
 ```
 
-If you want to quickly plot the entire billiard with default parameters, simply use the function `plot_billiard(bd)`:
+If you want to quickly plot the entire billiard with default parameters, simply use the function `plot(bd)`:
 
 ```@example 8
 using PyPlot
-plot_billiard(bd)
+plot(bd)
 savefig("billiard_example.svg"); nothing # hide
 ```
 ![](billiard_example.svg)
 
-`plot_billiard()` also sets up the axis to have equal aspect ratio and sets up the axis limits to be just large enough to contain the entire billiard.
+`plot()` also sets up the axis to have equal aspect ratio and sets up the axis limits to be just large enough to contain the entire billiard.
 
 
 
@@ -96,12 +96,12 @@ animate_evolution(p, bd, 50; savename = "penta")
 
 ## Periodic Billiards
 In order to plot periodic billiards, you have need to call a different method of
-[`plot_billiard`](@ref), since now you
+[`plot`](@ref), since now you
 also have to specify the limits of plotting. The
 methods provided are:
 ```julia
-plot_billiard(bd, xmin, ymin, xmax, ymax)
-plot_billiard(bd, xt::Vector{T}, yt::Vector{T})
+plot(bd, xmin, ymin, xmax, ymax)
+plot(bd, xt::Vector{T}, yt::Vector{T})
 ```
 The last one conveniently plots the combo of particle-trajectory and
 periodic-billiard taking care of all the details internally. Give the keyword
@@ -117,14 +117,14 @@ d2 = Ellipse([1.5, 0.5], r, 2r/3)
 bd = Billiard(bd.obstacles..., d, d2)
 p = Particle(1.0, 0.5, 0.2)
 xt, yt, vxt, vyt, t = construct(evolve!(p, bd, 10)...)
-plot_billiard(bd, xt, yt)
+plot(bd, xt, yt)
 plot_particle(p)
 savefig("rectperiodic.svg"); nothing # hide
 ```
 ![](rectperiodic.svg)
 
 And, you can also periodically plot billiards with hexagonal periodicity. Only give
-the keyword argument `hexagonal = true` to [`plot_billiard`](@ref). As an example:
+the keyword argument `hexagonal = true` to [`plot`](@ref). As an example:
 
 ```@example 8
 bd = billiard_hexagonal_sinai(0.3, 1.50; setting = "periodic")
@@ -136,7 +136,7 @@ p = MagneticParticle(-0.5, 0.5, π/5, 1.0)
 
 xt, yt = construct(evolve(p, bd, 10)...)
 
-plot_billiard(bd, xt, yt; hexagonal = true)
+plot(bd, xt, yt; hexagonal = true)
 savefig("hexperiodic.svg"); nothing # hide
 ```
 ![](hexperiodic.svg)

--- a/docs/src/visualizing.md
+++ b/docs/src/visualizing.md
@@ -3,7 +3,6 @@ All plotting functionality of `DynamicalBilliards` lies within a few well-define
 All plotting functions are brought into scope when `using PyPlot`. The functions are:
 ```@docs
 DynamicalBilliards.plot
-plot_particle
 plot_cyclotron
 animate_evolution
 ```
@@ -48,14 +47,14 @@ savefig("billiard_example.svg"); nothing # hide
 
 ### Plotting particles
 
-Following the above example, we create and plot a particle using the function `plot_particle`:
+Following the above example, we create and plot a particle using the function `plot`:
 ```@example 8
 p = randominside(bd)
-plot_particle(p)
+plot(p)
 # Plot one more particle with purple color,
 # pentagon shape and bigger size (default is s=30):
 p2 = randominside(bd)
-plot_particle(p2; color=(0.5, 0, 0.8), marker="p", s=60.0)
+plot(p2; color=(0.5, 0, 0.8), marker="p", s=60.0)
 savefig("particles_example.svg"); nothing # hide
 ```
 ![](particles_example.svg)
@@ -117,7 +116,7 @@ bd = Billiard(bd.obstacles..., d, d2)
 p = Particle(1.0, 0.5, 0.2)
 xt, yt, vxt, vyt, t = construct(evolve!(p, bd, 10)...)
 plot(bd, xt, yt)
-plot_particle(p)
+plot(p)
 savefig("rectperiodic.svg"); nothing # hide
 ```
 ![](rectperiodic.svg)

--- a/docs/src/visualizing.md
+++ b/docs/src/visualizing.md
@@ -5,7 +5,6 @@ All plotting functions are brought into scope when `using PyPlot`. The functions
 DynamicalBilliards.plot(::Obstacle)
 DynamicalBilliards.plot(::Billiard)
 DynamicalBilliards.plot(::AbstractParticle)
-plot_cyclotron
 animate_evolution
 ```
 
@@ -57,6 +56,8 @@ plot(p)
 # pentagon shape and bigger size (default is s=30):
 p2 = randominside(bd)
 plot(p2; color=(0.5, 0, 0.8), marker="p", s=60.0)
+p3 = randominside(bd, 2.0)
+plot(p3, true; color=(0, 0, 0.8), marker="o", s=60.0)
 savefig("particles_example.svg"); nothing # hide
 ```
 ![](particles_example.svg)
@@ -66,6 +67,7 @@ savefig("particles_example.svg"); nothing # hide
 ## Color conventions
 The default plotting settings have been chosen for maximum clarity and consistency. The color conventions followed are:
 * Particles are black.
+* Particle orbits use matplotlib's color cycle (first one is blue).
 * Reflecting obstacles (e.g. `Disk`, `FiniteWall` etc.) are green.
 * Randomly reflecting obstacles (e.g. `RandomDisk` or `RandomWall`) are purple.
 * Ray-splitting obstacles are red with dashed linestyle.
@@ -73,8 +75,6 @@ The default plotting settings have been chosen for maximum clarity and consisten
   (if and when plotted).
 * Doors (`InfiniteWall` with `isdoor=true`) are plotted with alternating black and
   cyan dashed lines.
-
-Particle orbits use matplotlib's color cycle (first one is blue).
 
 ## Animating the motion of a particle
 

--- a/docs/src/visualizing.md
+++ b/docs/src/visualizing.md
@@ -3,7 +3,6 @@ All plotting functionality of `DynamicalBilliards` lies within a few well-define
 All plotting functions are brought into scope when `using PyPlot`. The functions are:
 ```@docs
 DynamicalBilliards.plot
-plot_obstacle
 plot_particle
 plot_cyclotron
 animate_evolution
@@ -18,9 +17,9 @@ using DynamicalBilliards, PyPlot
 bd = billiard_sinai()
 
 figure()
-plot_obstacle(bd[2]);
-plot_obstacle(bd[4], color = "blue", linestyle = "dotted", lw = 5.0);
-plot_obstacle(bd[1], facecolor = "yellow", edgecolor = "black");
+plot(bd[2]);
+plot(bd[4], color = "blue", linestyle = "dotted", lw = 5.0);
+plot(bd[1], facecolor = "yellow", edgecolor = "black");
 savefig("rand_obstacles.svg"); nothing # hide
 ```
 ![](rand_obstacles.svg)

--- a/docs/src/visualizing.md
+++ b/docs/src/visualizing.md
@@ -2,7 +2,9 @@ All plotting functionality of `DynamicalBilliards` lies within a few well-define
 
 All plotting functions are brought into scope when `using PyPlot`. The functions are:
 ```@docs
-DynamicalBilliards.plot
+DynamicalBilliards.plot(::Obstacle)
+DynamicalBilliards.plot(::Billiard)
+DynamicalBilliards.plot(::AbstractParticle)
 plot_cyclotron
 animate_evolution
 ```

--- a/src/DynamicalBilliards.jl
+++ b/src/DynamicalBilliards.jl
@@ -69,7 +69,7 @@ end
 using Requires
 function __init__()
     @require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" begin
-        import PyPlot: plot
+        import .PyPlot: plot
         dir = joinpath(@__DIR__, "plotting")
         for f in readdir(dir)
             include(joinpath(dir, f))

--- a/src/DynamicalBilliards.jl
+++ b/src/DynamicalBilliards.jl
@@ -69,6 +69,7 @@ end
 using Requires
 function __init__()
     @require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" begin
+        import PyPlot: plot
         dir = joinpath(@__DIR__, "plotting")
         for f in readdir(dir)
             include(joinpath(dir, f))

--- a/src/plotting/animations.jl
+++ b/src/plotting/animations.jl
@@ -12,7 +12,7 @@ Animate the evolution of particle `p` in billiard `bd`, for a total of
   * `framerate = 5` : Rate of drawing new collisions (per second).
     Both during showing animation and during saving it.
   * `col_to_plot = 5` : How many previous collisions are shown during the animation.
-  * `particle_kwargs` : A `NamedTuple` of keywords passed to [`plot_particle`](@ref).
+  * `particle_kwargs` : A `NamedTuple` of keywords passed to [`plot`](@ref).
   * `orbit_kwargs` : A `NamedTuple` of keywrods passed to `PyPlot.plot`
     which plots the orbit of the particle (`line` object).
   * `savename = nothing` : If `nothing`, nothing is saved.
@@ -78,7 +78,7 @@ function animate_evolution(par::AbstractParticle, bd, colnumber, raysplit = noth
         line[:set_xdata](xpd)
         line[:set_ydata](ypd)
 
-        point, quiv = plot_particle(p; particle_kwargs...)
+        point, quiv = plot(p; particle_kwargs...)
 
         if savename != nothing
             s = savename*"_$(i+1).png"

--- a/src/plotting/animations.jl
+++ b/src/plotting/animations.jl
@@ -38,7 +38,7 @@ function animate_evolution(par::AbstractParticle, bd, colnumber, raysplit = noth
     p = copy(par)
     if newfig == true
         fig = PyPlot.figure(figsize = figsize)
-        plot_billiard(bd; ax = PyPlot.gca())
+        plot(bd; ax = PyPlot.gca())
     end
 
     disable_axis && PyPlot.axis("off")

--- a/src/plotting/billiards.jl
+++ b/src/plotting/billiards.jl
@@ -1,5 +1,5 @@
 using InteractiveUtils
-export plot_billiard
+export plot
 
 function nonperiodic(bd::Billiard)
     toplot = Obstacle{eltype(bd)}[]
@@ -16,18 +16,18 @@ periodicerror() = throw(ArgumentError(
 
 
 """
-    plot_billiard(bd::Billiard; ax = (figure(); gca()))
+    plot(bd::Billiard; ax = (figure(); gca()))
 Plot all obstacles in `bd` using the default arguments, set
 `xlim` and `ylim` to be 20% larger than `cellsize` and
 set the axis aspect ratio to equal.
 
-    plot_billiard(bd, xmin, ymin, xmax, ymax; hexagonal = false, ax = (figure(); gca()))
+    plot(bd, xmin, ymin, xmax, ymax; hexagonal = false, ax = (figure(); gca()))
 Plot the given **periodic** billiard `bd`, repeatedly
 plotting from `(xmin, ymin)` to `(xmax, ymax)`.
 Works for either rectangular periodic billiards, or hexagonal ones. Use
 keyword `hexagonal` to denote which one you want.
 
-    plot_billiard(bd, xt::Vector, yt::Vector; hexagonal = false,
+    plot(bd, xt::Vector, yt::Vector; hexagonal = false,
     ax = (figure(); gca()), plot_orbit = true, orbit_color = "C0")
 Plot the given **periodic** billiard `bd` using the limits defined
 by `xt` and `yt`.
@@ -35,7 +35,7 @@ by `xt` and `yt`.
 Set the keyword argument `plot_orbit = false` to not
 plot the orbit defined by `(xt, yt)` and only use the limits.
 """
-function plot_billiard(bd::Billiard{T};
+function plot(bd::Billiard{T};
     ax = (PyPlot.figure(); PyPlot.gca())) where {T}
     PyPlot.sca(ax)
     for obst in bd; plot_obstacle(obst); end
@@ -51,7 +51,7 @@ function plot_billiard(bd::Billiard{T};
     return nothing
 end
 
-function plot_billiard(bd::Billiard, xmin, ymin, xmax, ymax;
+function plot(bd::Billiard, xmin, ymin, xmax, ymax;
     hexagonal = false, ax = (PyPlot.figure(); PyPlot.gca()))
 
     isperiodic(bd) || periodicerror()
@@ -74,14 +74,14 @@ function plot_billiard(bd::Billiard, xmin, ymin, xmax, ymax;
     return nothing
 end
 
-function plot_billiard(bd, xt::AbstractVector, yt::AbstractVector;
+function plot(bd, xt::AbstractVector, yt::AbstractVector;
     hexagonal = false, ax = (PyPlot.figure(); PyPlot.gca()),
     plot_orbit = true, orbit_color = "C0")
 
     xmin = minimum(xt); xmax = maximum(xt)
     ymin = minimum(yt); ymax = maximum(yt)
 
-    plot_billiard(bd, xmin, ymin, xmax, ymax; hexagonal = hexagonal, ax = ax)
+    plot(bd, xmin, ymin, xmax, ymax; hexagonal = hexagonal, ax = ax)
 
     if plot_orbit
         PyPlot.sca(ax)

--- a/src/plotting/billiards.jl
+++ b/src/plotting/billiards.jl
@@ -20,20 +20,23 @@ Plot all obstacles in `bd` using the default arguments, set
 `xlim` and `ylim` to be 20% larger than `cellsize` and
 set the axis aspect ratio to equal.
 
-    plot(bd, xmin, ymin, xmax, ymax; hexagonal = false, ax = (figure(); gca()))
+    plot(bd::Billiard, xmin, ymin, xmax, ymax;
+         hexagonal = false, ax = (figure(); gca()))
 Plot the given **periodic** billiard `bd`, repeatedly
 plotting from `(xmin, ymin)` to `(xmax, ymax)`.
 Works for either rectangular periodic billiards, or hexagonal ones. Use
 keyword `hexagonal` to denote which one you want.
 
-    plot(bd, xt::Vector, yt::Vector; hexagonal = false,
-    ax = (figure(); gca()), plot_orbit = true, orbit_color = "C0")
+    plot(bd::Billiard, xt::Vector, yt::Vector; hexagonal = false,
+         ax = (figure(); gca()), plot_orbit = true, orbit_color = "C0")
 Plot the given **periodic** billiard `bd` using the limits defined
 by `xt` and `yt`.
 
 Set the keyword argument `plot_orbit = false` to not
 plot the orbit defined by `(xt, yt)` and only use the limits.
 """
+function plot(bd::Billiard) end
+
 function plot(bd::Billiard{T};
     ax = (PyPlot.figure(); PyPlot.gca())) where {T}
     PyPlot.sca(ax)

--- a/src/plotting/billiards.jl
+++ b/src/plotting/billiards.jl
@@ -38,7 +38,7 @@ plot the orbit defined by `(xt, yt)` and only use the limits.
 function plot(bd::Billiard{T};
     ax = (PyPlot.figure(); PyPlot.gca())) where {T}
     PyPlot.sca(ax)
-    for obst in bd; plot_obstacle(obst); end
+    for obst in bd; plot(obst); end
     xmin, ymin, xmax, ymax = cellsize(bd)
     dx = xmax - xmin; dy = ymax - ymin
     ax[:set_aspect]("equal")
@@ -127,7 +127,7 @@ function plot_periodic_rectangle(bd, xmin, ymin, xmax, ymax)
         for y in dy
             disp = SVector(x,y)
             for obst in toplot
-                plot_obstacle(translate(obst, disp))
+                plot(translate(obst, disp))
             end
         end
     end
@@ -160,8 +160,8 @@ function plot_periodic_hexagon(bd, xmin, ymin, xmax, ymax)
     for d in obstacles
         for j ∈ jmin:jmax
             for i ∈ imin:imax
-                plot_obstacle(translate(d, j*basis_a + i*basis_c))
-                plot_obstacle(translate(d, j*basis_a + i*basis_c + basis_b))
+                plot(translate(d, j*basis_a + i*basis_c))
+                plot(translate(d, j*basis_a + i*basis_c + basis_b))
             end
         end
     end

--- a/src/plotting/billiards.jl
+++ b/src/plotting/billiards.jl
@@ -1,5 +1,4 @@
 using InteractiveUtils
-export plot
 
 function nonperiodic(bd::Billiard)
     toplot = Obstacle{eltype(bd)}[]

--- a/src/plotting/boundarymap_plots.jl
+++ b/src/plotting/boundarymap_plots.jl
@@ -22,12 +22,19 @@ function plot_boundarymap(ξs, sφs, intervals;
     ax = (PyPlot.figure(); PyPlot.gca()),
     color = "C0", bordercolor = "C3", ms = 1.0, obstacleindices = true, kwargs...)
 
-    # Plot PSOS
-    for (i, (xis, sphis)) in enumerate(zip(ξs, sφs))
-        c = typeof(color) <: AbstractVector ? color[i] : color
+    # Plot the points
+    if typeof(ξs) <: Vector{<:Real}
+        c = typeof(color) <: AbstractVector ? color[1] : color
 
-        ax[:plot](xis, sphis; marker="o", color = c,
+        ax[:plot](ξs, sφs; marker="o", color = c,
         linestyle="None", ms = ms, kwargs...)
+    else            
+        for (i, (xis, sphis)) in enumerate(zip(ξs, sφs))
+            c = typeof(color) <: AbstractVector ? color[i] : color
+
+            ax[:plot](xis, sphis; marker="o", color = c,
+            linestyle="None", ms = ms, kwargs...)
+        end
     end
 
     # Plot obstacle limits

--- a/src/plotting/obstacles.jl
+++ b/src/plotting/obstacles.jl
@@ -1,4 +1,4 @@
-export plot_obstacle
+export plot
 
 obcolor(::Obstacle) = (0,0.6,0)
 obcolor(::Union{RandomWall, RandomDisk}) = (149/255, 88/255, 178/255)
@@ -11,7 +11,7 @@ obls(::Union{SplitterWall, Antidot, Ellipse}) = "dashed"
 obls(::PeriodicWall) = "dotted"
 
 """
-    plot_obstacle(obst::Obstacle; kwargs...)
+    plot(obst::Obstacle; kwargs...)
 Plot given obstacle on the current `PyPlot` axes.
 
 The default arguments for each type of obstacle have been chosen for maximum
@@ -21,7 +21,7 @@ The `kwargs...` given by the user are keywords passed directly into PyPlot's
 constructors. For `Wall` obstacles, kwargs are passed into `PyPlot.plot()`. For
 `Circular` obstacles, kwargs are passed into `matplotlib.patches.Circle` or `Arc`.
 """
-function plot_obstacle(d::Circular; kwargs...)
+function plot(d::Circular; kwargs...)
     edgecolor = obcolor(d)
     facecolor = (edgecolor..., obalpha(d))
     circle1 = PyPlot.plt[:Circle](d.c, d.r;
@@ -30,7 +30,7 @@ function plot_obstacle(d::Circular; kwargs...)
     PyPlot.gca()[:add_artist](circle1)
 end
 
-function plot_obstacle(d::Semicircle; kwargs...)
+function plot(d::Semicircle; kwargs...)
     theta1 = atan(d.facedir[2], d.facedir[1])*180/π + 90
     theta2 = theta1 + 180
     edgecolor = obcolor(d)
@@ -39,7 +39,7 @@ function plot_obstacle(d::Semicircle; kwargs...)
     PyPlot.gca()[:add_artist](s1)
 end
 
-function plot_obstacle(w::Wall; kwargs...)
+function plot(w::Wall; kwargs...)
     if typeof(w) <: FiniteWall &&  w.isdoor
        PyPlot.plot([w.sp[1],w.ep[1]],[w.sp[2],w.ep[2]];
        color="black", linestyle = "-", lw = 2.0, kwargs...)
@@ -52,7 +52,7 @@ function plot_obstacle(w::Wall; kwargs...)
     end
 end
 
-function plot_obstacle(e::Ellipse; kwargs...)
+function plot(e::Ellipse; kwargs...)
     edgecolor = obcolor(e)
     facecolor = (edgecolor..., obalpha(e))
     ellipse = PyPlot.matplotlib[:patches][:Ellipse](e.c, 2e.a, 2e.b;

--- a/src/plotting/obstacles.jl
+++ b/src/plotting/obstacles.jl
@@ -19,6 +19,8 @@ The `kwargs...` given by the user are keywords passed directly into PyPlot's
 constructors. For `Wall` obstacles, kwargs are passed into `PyPlot.plot()`. For
 `Circular` obstacles, kwargs are passed into `matplotlib.patches.Circle` or `Arc`.
 """
+function plot(d::Obstacle) end
+
 function plot(d::Circular; kwargs...)
     edgecolor = obcolor(d)
     facecolor = (edgecolor..., obalpha(d))

--- a/src/plotting/obstacles.jl
+++ b/src/plotting/obstacles.jl
@@ -1,5 +1,3 @@
-export plot
-
 obcolor(::Obstacle) = (0,0.6,0)
 obcolor(::Union{RandomWall, RandomDisk}) = (149/255, 88/255, 178/255)
 obcolor(::Union{SplitterWall, Antidot, Ellipse}) = (0.8,0.0,0)

--- a/src/plotting/particles.jl
+++ b/src/plotting/particles.jl
@@ -1,5 +1,3 @@
-export plot_cyclotron
-
 """
     plot_cyclotron(p::MagneticParticle; use_cell=true, kwargs...)
 Plot the circle traced by the free particle motion. Optionally use `p.current_cell` for
@@ -15,11 +13,10 @@ function plot_cyclotron(p::MagneticParticle; use_cell=true, kwargs...)
   edgecolor = (0.0,0.0,0.8, 0.5), linewidth = 2.0, facecolor = (0., 0.0, 0.8, 0.05),
   kwargs...)
   PyPlot.gca()[:add_artist](circle1)
-  PyPlot.show()
 end
 
 """
-    plot(p::AbstractParticle; use_cell=true, kwargs...)
+    plot(p::AbstractParticle [, cyclotron=false]; use_cell=true, kwargs...)
 Plot given particle on the current `PyPlot` axes. Optionally use `p.current_cell` for
 the particle's position. Given `kwargs...` are passed onto `PyPlot.scatter`.
 
@@ -27,10 +24,16 @@ The particle is represented as a small ball (`PyPlot.scatter`) and a small arrow
 (`PyPlot.quiver`).
 All `kwargs...` are given to `scatter` but if a keyword argument `color` is given,
 it is also passed to `quiver`.
+
+Optionally you can plot the cyclotron traced by a `MagneticParticle` by giving
+`true` as second argument.
 """
 function plot(p::AbstractParticle) end
 
-function plot(p::AbstractParticle{T}; use_cell=true, kwargs...) where {T}
+function plot(p::AbstractParticle{T}, cycl::Bool = false; use_cell=true, kwargs...) where {T}
+  if typeof(p) <: MagneticParticle && cycl
+    plot_cyclotron(p; use_cell = use_cell)
+  end
   pos = use_cell ? p.pos + p.current_cell : p.pos
   kwargs = Dict(kwargs)
   # Set same color for arrow and point:

--- a/src/plotting/particles.jl
+++ b/src/plotting/particles.jl
@@ -1,4 +1,4 @@
-export plot_cyclotron, plot
+export plot_cyclotron
 
 """
     plot_cyclotron(p::MagneticParticle; use_cell=true, kwargs...)

--- a/src/plotting/particles.jl
+++ b/src/plotting/particles.jl
@@ -1,4 +1,4 @@
-export plot_cyclotron, plot_particle
+export plot_cyclotron, plot
 
 """
     plot_cyclotron(p::MagneticParticle; use_cell=true, kwargs...)
@@ -19,7 +19,7 @@ function plot_cyclotron(p::MagneticParticle; use_cell=true, kwargs...)
 end
 
 """
-    plot_particle(p::AbstractParticle; use_cell=true, kwargs...)
+    plot(p::AbstractParticle; use_cell=true, kwargs...)
 Plot given particle on the current `PyPlot` axes. Optionally use `p.current_cell` for
 the particle's position. Given `kwargs...` are passed onto `PyPlot.scatter`.
 
@@ -28,7 +28,7 @@ The particle is represented as a small ball (`PyPlot.scatter`) and a small arrow
 All `kwargs...` are given to `scatter` but if a keyword argument `color` is given,
 it is also passed to `quiver`.
 """
-function plot_particle(p::AbstractParticle; use_cell=true, kwargs...)
+function plot(p::AbstractParticle; use_cell=true, kwargs...)
   pos = use_cell ? p.pos + p.current_cell : p.pos
   kwargs = Dict(kwargs)
   # Set same color for arrow and point:

--- a/src/plotting/particles.jl
+++ b/src/plotting/particles.jl
@@ -28,7 +28,9 @@ The particle is represented as a small ball (`PyPlot.scatter`) and a small arrow
 All `kwargs...` are given to `scatter` but if a keyword argument `color` is given,
 it is also passed to `quiver`.
 """
-function plot(p::AbstractParticle; use_cell=true, kwargs...)
+function plot(p::AbstractParticle) end
+
+function plot(p::AbstractParticle{T}; use_cell=true, kwargs...) where {T}
   pos = use_cell ? p.pos + p.current_cell : p.pos
   kwargs = Dict(kwargs)
   # Set same color for arrow and point:


### PR DESCRIPTION
Don't merge this yet. Fixes #152.

Tests are passing, but `plot` is not defined.  As far as I understand, to extend `PyPlot.plot()`, we need something like `import PyPlot: plot`, but since we don't explicitly REQUIRE PyPlot, that's not safe.  Is there a better way to handle that?