### PR TITLE
Allow timeseries! to evolve particle until a condition is met

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.10.0
+* It is now possible in `timeseries!` to evolve a particle until a certain boolean condition is met.
+
 # 3.9.0
 * It is now possible to create animations as gifs.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalBilliards"
 uuid = "4986ee89-4ee5-5cef-b6b8-e49ba721d7a5"
 repo = "https://github.com/JuliaDynamics/DynamicalBilliards.jl.git"
-version = "3.9.1"
+version = "3.10.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,6 +10,8 @@ dynamical billiards in two dimensions.
     Check out the example in the [tutorials](tutorials/examples/#julia-logo-billiard) page to see the code that created and animated the "Julia Billiard", which is
     the logo of our package!
 
+!!! info "Latest news"
+    The [`timeseries!`](@ref) function now supports evolving particles until a certain condition (specified by a function) is met.
 
 ## About Billiards
 

--- a/src/DynamicalBilliards.jl
+++ b/src/DynamicalBilliards.jl
@@ -29,8 +29,12 @@ include("billiards/standard_billiards.jl")
 
 include("timeevolution/collisions.jl")
 include("timeevolution/propagation.jl")
+include("timeevolution/timeseries.jl")
 include("timeevolution/highleveltimes.jl")
 
+##########################################
+# Advanced                               #
+##########################################
 include("boundary/boundarymap.jl")
 include("boundary/phasespacetools.jl")
 
@@ -41,10 +45,7 @@ include("mushroomtools.jl")
 export MushroomTools
 
 include("raysplitting.jl")
-include("timeseries.jl")
-
 include("parallel.jl")
-
 include("testing.jl")
 
 ####################################################

--- a/src/timeevolution/propagation.jl
+++ b/src/timeevolution/propagation.jl
@@ -1,4 +1,4 @@
-export bounce!, evolve, ispinned, evolve!, propagate!
+export bounce!, ispinned, propagate!
 
 @inline increment_counter(::Int, t_to_write) = 1
 @inline increment_counter(::T, t_to_write) where {T<:AbstractFloat} = t_to_write
@@ -156,9 +156,6 @@ incidence angle φ, if T(φ) > rand(), ray-splitting occurs.
 
 resolvecollision!(p::MagneticParticle, o::PeriodicWall) = periodicity!(p, o)
 
-#####################################################################################
-# ispinned, Evolve & Construct
-#####################################################################################
 """
     ispinned(p::MagneticParticle, bd::Billiard)
 Return `true` if the particle is pinned with respect to the billiard.

--- a/src/timeevolution/timeseries.jl
+++ b/src/timeevolution/timeseries.jl
@@ -106,15 +106,15 @@ evolve(bd::Billiard, args...; kwargs...) =
 #####################################################################################
 """
     timeseries!([p::AbstractParticle,] bd::Billiard, t; dt, warning)
-Evolve the given particle `p` inside the billiard `bd`.  If `t` is of type
-`AbstractFloat`, evolve for as much time as `t`. If however `t` is of type `Int`,
-evolve for as many collisions as `t`.
-Return:
-* x position time-series
-* y position time-series
-* x velocity time-series
-* y velocity time-series
-* time vector
+Evolve the given particle `p` inside the billiard `bd` for the condition `t`
+and return the x, y, vx, vy timeseries and the time vector.
+If `t` is of type `AbstractFloat`, then evolve for as much time as `t`.
+If however `t` is of type `Int`, evolve for as many collisions as `t`.
+Otherwise, `t` can be any function, that takes as an input `t(n, τ, i, p)`
+and returns `true` when the evolution should terminate. Here `n` is the amount
+of obstacles collided with so far, `τ` the amount time evolved so far, `i`
+the obstacle just collided with and `p` the particle (so you can access e.g.
+`p.pos`).
 
 This function mutates the particle, use `timeseries` otherwise. If a particle is
 not given, a random one is picked through [`randominside`](@ref).

--- a/test/extended_tests.jl
+++ b/test/extended_tests.jl
@@ -47,7 +47,15 @@ function test_visited_obstacles(p, bd, N = 50)
 end
 billiards_testset("Visited obstacles", test_visited_obstacles; caller = ergodic_tests)
 
+function test_predicate_ts(p, bd, N = 1e3)
+    xmin, ymin, xmax, ymax = cellsize(bd[1])
+    f(n, t, i, p) = i == 1
 
+    xt, yt = timeseries(p, bd, Int(N), dt = Inf)
+    @test (xt[end] == xmin || xt[end] == xmax)
+    @test (yt[end] == ymin || yt[end] == ymax)
+end
+billiards_testset("Predicate function", test_visited_obstacles; caller = ergodic_tests)
 
 function test_movin_periodic(p, bd, N = 1e3)
     xmin, ymin, xmax, ymax = cellsize(bd)


### PR DESCRIPTION
This is related to #194 and in fact implements the first half of it. Turns out it is actually pretty easy to evolve until a predicate is met. The difficult part would be to actually implement flexible data collection, but I think to do this one would really need to think about it and design it properly!

Regardless, the first part, of extending any kind of evolution to arbitrary predicates that I have implemented here can be readily applied to all other functions like e.g. `evolve, mean collision time,` whatever.